### PR TITLE
fix: use google/promises as dependency instead of vendored binaries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,12 @@ let package = Package(
                 "FirebaseSharedSwift",
                 "FirebaseCoreExtension",
                 "FirebaseSessions",
-                "FirebaseRemoteConfigInterop",
-                "FBLPromises",
-                "Promises"
+                "FirebaseRemoteConfigInterop"
             ]
         ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/google/promises.git", "2.4.0" ..< "3.0.0")
     ],
     targets: [
         .binaryTarget(name: "FirebaseAnalytics", path: "Frameworks/FirebaseAnalytics/FirebaseAnalytics.xcframework"),
@@ -54,8 +55,6 @@ let package = Package(
         .binaryTarget(name: "FirebaseSharedSwift", path: "Frameworks/FirebaseRemoteConfig/FirebaseSharedSwift.xcframework"),
         .binaryTarget(name: "FirebaseCoreExtension", path: "Frameworks/FirebaseCrashlytics/FirebaseCoreExtension.xcframework"),
         .binaryTarget(name: "FirebaseSessions", path: "Frameworks/FirebaseCrashlytics/FirebaseSessions.xcframework"),
-        .binaryTarget(name: "FBLPromises", path: "Frameworks/FirebaseAnalytics/FBLPromises.xcframework"),
-        .binaryTarget(name: "Promises", path: "Frameworks/FirebaseCrashlytics/Promises.xcframework"),
         .target(
             name: "FirebaseBinaries",
             dependencies: [
@@ -76,8 +75,8 @@ let package = Package(
                 "FirebaseCoreExtension",
                 "FirebaseSessions",
                 "FirebaseRemoteConfigInterop",
-                "FBLPromises",
-                "Promises"
+                .product(name: "FBLPromises", package: "Promises"),
+                .product(name: "Promises", package: "Promises")
             ]
         )
     ]


### PR DESCRIPTION
## Проблема

Релиз 12.14.0 добавил вендоренные `binaryTarget`'ы `FBLPromises` и `Promises`. У потребителей, которые подключают `google/promises` напрямую (как kcell-activ-ios — там продукты `FBLPromises`/`Promises` слинкованы в app/extension таргеты ещё со времён 12.6.x, когда пакет их не вендорил), граф перестаёт резолвиться:

```
xcodebuild: error: Could not resolve package dependencies:
  multiple packages ('firebasebinaries', 'promises') declare targets with a conflicting name: 'FBLPromises'; target names need to be unique across the package graph
  multiple packages ('firebasebinaries', 'promises') declare targets with a conflicting name: 'Promises'; target names need to be unique across the package graph
```

Из-за этого падает CI kcell-activ-ios (чистый резолв берёт последний 12.x). Сейчас мы запинились на `exact: 12.6.1` как временную меру.

## Решение

Вместо бандла бинарей — source-зависимость на `google/promises` (ровно так это делает официальный `firebase-ios-sdk` для своей binary-дистрибуции). SPM дедуплицирует пакет по identity, поэтому работают обе конфигурации потребителей: и с прямой зависимостью на promises, и без неё.

## Проверка

Мини-потребитель (`FirebaseBinaries` + прямая зависимость `google/promises` — форма графа kcell-activ-ios):
- манифест 12.14.0 → воспроизводит ошибку конфликта слово в слово;
- манифест из этого PR → `swift build` зелёный, `FBLPromises` (ObjC) и `Promises` (Swift) собираются из source и линкуются.

## Follow-up

`Frameworks/FirebaseAnalytics/FBLPromises.xcframework` и `Frameworks/FirebaseCrashlytics/Promises.xcframework` манифестом больше не используются — их можно удалить из репозитория отдельным коммитом (не делал в этом PR, чтобы не тащить изменения бинарей).